### PR TITLE
feat: add TypeScript definitions, allow falsy errors, and refine erro…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "license": "MIT",
   "devDependencies": {
     "@tc39/ecma262-biblio": "^2.1.2753",
-    "ecmarkup": "^19.0.0"
+    "@types/node": "^22.4.1",
+    "ecmarkup": "^19.0.0",
+    "typescript": "^5.5.4"
   },
   "engines": {
     "node": ">= 12"

--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -13,22 +13,16 @@ interface Function {
     this: T,
     ...args: Parameters<T>
   ): [ReturnType<T>] extends [never]
-    ? readonly [NonNullable<unknown> | Error, never]
+    ? readonly [{}, never]
     : ReturnType<T> extends Promise<never>
-      ? readonly [NonNullable<unknown> | Error, never]
+      ? readonly [{}, never]
       : ReturnType<T> extends Promise<infer R>
-        ? Promise<
-            | readonly [NonNullable<unknown> | Error, undefined]
-            | readonly [null, Awaited<R>]
-          >
-        :
-            | readonly [NonNullable<unknown> | Error, undefined]
-            | readonly [null, ReturnType<T>]
+        ? Promise<readonly [{}, undefined] | readonly [null, Awaited<R>]>
+        : readonly [{}, undefined] | readonly [null, ReturnType<T>]
 }
 
 interface Promise<T = unknown> {
   [Symbol.result](): Promise<
-    | readonly [NonNullable<unknown> | Error, undefined]
-    | readonly [null, Awaited<T>]
+    readonly [{}, undefined] | readonly [null, Awaited<T>]
   >
 }

--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -12,14 +12,18 @@ interface Function {
   [Symbol.result]<T extends (...args: any[]) => any>(
     this: T,
     ...args: Parameters<T>
-  ): ReturnType<T> extends Promise<infer R>
-    ? Promise<
-        | readonly [NonNullable<unknown> | Error, undefined]
-        | readonly [null, Awaited<R>]
-      >
-    :
-        | readonly [NonNullable<unknown> | Error, undefined]
-        | readonly [null, ReturnType<T>]
+  ): [ReturnType<T>] extends [never]
+    ? readonly [NonNullable<unknown> | Error, never]
+    : ReturnType<T> extends Promise<never>
+      ? readonly [NonNullable<unknown> | Error, never]
+      : ReturnType<T> extends Promise<infer R>
+        ? Promise<
+            | readonly [NonNullable<unknown> | Error, undefined]
+            | readonly [null, Awaited<R>]
+          >
+        :
+            | readonly [NonNullable<unknown> | Error, undefined]
+            | readonly [null, ReturnType<T>]
 }
 
 interface Promise<T = unknown> {

--- a/polyfill.d.ts
+++ b/polyfill.d.ts
@@ -1,0 +1,30 @@
+/// <reference no-default-lib="true"/>
+
+interface SymbolConstructor {
+  /**
+   * A method that is used with the safe assignment operator `?=`.
+   * Any object that implements the `Symbol.result` method should return `[error, undefined]` or `[null, data]` tuple.
+   */
+  readonly result: unique symbol
+}
+
+interface Function {
+  [Symbol.result]<T extends (...args: any[]) => any>(
+    this: T,
+    ...args: Parameters<T>
+  ): ReturnType<T> extends Promise<infer R>
+    ? Promise<
+        | readonly [NonNullable<unknown> | Error, undefined]
+        | readonly [null, Awaited<R>]
+      >
+    :
+        | readonly [NonNullable<unknown> | Error, undefined]
+        | readonly [null, ReturnType<T>]
+}
+
+interface Promise<T = unknown> {
+  [Symbol.result](): Promise<
+    | readonly [NonNullable<unknown> | Error, undefined]
+    | readonly [null, Awaited<T>]
+  >
+}

--- a/polyfill.js
+++ b/polyfill.js
@@ -14,7 +14,7 @@ Function.prototype[Symbol.result] = function (...args) {
   } catch (error) {
     // throw undefined would break the pattern of destructuring the result type.
     // in [error, data], both error and data would be undefined
-    return [error || new Error("Thrown error is falsy")]
+    return [error ?? new Error("Thrown error is nullish"), undefined]
   }
 }
 
@@ -23,6 +23,6 @@ Promise.prototype[Symbol.result] = async function () {
     const result = await this
     return [null, result]
   } catch (error) {
-    return [error || new Error("Thrown error is falsy")]
+    return [error ?? new Error("Thrown error is nullish"), undefined]
   }
 }


### PR DESCRIPTION
## Overview

This pull request enhances the original `Symbol.result` proposal by introducing TypeScript type definitions, allowing falsy values for errors, and refining the documentation to exclude `null` as a possible value for data when an error occurs. These changes aim to improve consistency, clarity, and type safety, making the proposal more robust and easier for developers to implement in real-world applications.

## Key Enhancements and Rationale

1. **TypeScript Definitions**:

   - **New Type Definitions**: TypeScript definitions (`polyfill.d.ts`) have been added to enforce the usage pattern `[error, undefined]` or `[null, data]`. This provides clear and enforceable typing for the `Symbol.result` method, ensuring consistent behavior when using the `?=` operator. Developers can benefit from compile-time checks and improved tooling support.
   - **Support for Functions and Promises**: The TypeScript definitions cover both synchronous and asynchronous functions, as well as promises, offering robust typing that aligns with the proposed error and result handling.

2. **Allowance of Falsy Error Values**:

   - **Support for Meaningful Falsy Values**: Falsy values such as `false`, `""`, `0`, and `0n` are now supported as valid error states. Instead of using the logical OR (`||`) operator, the nullish coalescing operator (`??`) is used. This approach ensures that these falsy values are correctly preserved and recognized as valid errors, allowing for more precise and meaningful error handling, particularly in cases where these values carry specific significance.
   - **Strict Error Checking**: To ensure that these falsy values are not mistakenly overlooked as errors, strict comparison to `null` should be used when checking for errors. This guarantees that all falsy values are properly considered as potential errors when appropriate.

   ```ts
   const [error, data] ?= action()
   if (error !== null) {
     // Handle error
   } else {
     // Handle data
   }
   ```

3. **Refinement of Documentation to Exclude `null` as a Possible Data Value When an Error Occurs**:

   - **Simplified Error Checking**: The documentation has been updated to reflect that `[error, undefined]` should be used instead of `[error, null | undefined]`. This change clarifies that when an error is present, data should always be `undefined`, avoiding ambiguity and making error handling more straightforward.
   - **Consistency with JavaScript Practices**: By excluding `null` as a possible data value when an error occurs in the documentation, the proposal aligns more closely with common JavaScript practices, where `undefined` typically signifies the absence of a value.
