### PR TITLE
feat: Safe assignment polyfill V2, introducing Function#result() method

### DIFF
--- a/polyfill.v2.js
+++ b/polyfill.v2.js
@@ -1,0 +1,21 @@
+/**
+ * @description Safe assignment polyfill V2, introducing Function#result() method,
+ * can handle functions that returns Promises.
+ * 
+ * This polyfill drops `@@result` symbol from first polyfill [/polyfill.js]
+ */
+
+Function.prototype.result = function (...args) {
+  try {
+    const ret = this.apply(this, args);
+
+    if (Object.getPrototypeOf(ret) === Promise.prototype) {
+      return ret.then(val => [null, val], err => [err]);
+    }
+
+    return [null, ret];
+
+  } catch (err) {
+    return [err];
+  }
+}


### PR DESCRIPTION
This pull request solves some problems discussed on many issues:

credits to @rockedpanda comment in #45 issue.

- It doesn't introduce special syntax nor punctuation tokens that is very hard to parse or understand by humans.
  This problem was mentioned in this issues: #38
- It doesn't bring up order-matters problems.
  This problem was mentioned in this issues: #41
  It basically talks about the order of the following expressions:
  > ```js
  > // most likely this is the only correct way, since we wrapping await
  > // with try expression;
  > const [parseError, json] = try await response.json();
  >
  > // anyways most likely there will be such cases, and this will be syntax error
  > // on Babel, ESLint and Typescript
  > // or runtime error when json has promise, instead of result
  > const [parseError, json] = await try response.json();
  > ```

Some examples usage of this new polyfill:
```js
// Function.result() returns a promise if the underlying function returns a promise.
const [error, response] = await fetch.result("https://example.org");
// You can't forget the order, any function has the method result (even async functions)

const [error, obj] = JSON.parse.result("bad");
```